### PR TITLE
Add `main` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
       "color-parser/index.js": "index.js",
       "color-parser/colors.js": "colors.js"
     }
-  }
+  },
+  "main": "index"
 }


### PR DESCRIPTION
Needed for CommonJS systems, like Mr, that don't load index.js by default.
