### PR TITLE
Fix for incorrect color parsing for certain strings.

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,5 +1,5 @@
 
-module.exports = {
+module.exports = Object.create(null, {
     aliceblue: [240, 248, 255]
   , antiquewhite: [250, 235, 215]
   , aqua: [0, 255, 255]
@@ -148,4 +148,4 @@ module.exports = {
   , whitesmoke: [245, 245, 245]
   , yellow: [255, 255, 0]
   , yellowgreen: [154, 205, 5]
-};
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "color-parser",
   "repo": "component/color-parser",
   "description": "CSS color string parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "keywords": [
     "color",


### PR DESCRIPTION
The color-parser looks up color names in an object that inherits from the object prototype, this causes lookups like `color["constructor"]` to return a function, which then causes the parser to return the malformed color `{r: undefined, g: undefined, b: undefined }`.

This PR fixes that issue.

Fixes #7.